### PR TITLE
fix: use path.basename instead of direct file extension replace

### DIFF
--- a/src/cli/commands/compile.ts
+++ b/src/cli/commands/compile.ts
@@ -49,9 +49,7 @@ export async function compileCommand(input: string, options: any) {
                     outputCode = await prettier.format(outputCode, { parser: 'babel' });
                 }
 
-                const outputFile = outputPath
-                    ? path.join(outputPath, path.basename(file, '.jolly') + '.js')
-                    : file.replace('.jolly', '.js');
+                const outputFile = path.join(outputPath ?? '', path.basename(file, '.jolly') + '.js');
 
                 fs.writeFileSync(outputFile, outputCode, 'utf-8');
                 spinner.succeed(chalk.green(`Compiled ${file} -> ${outputFile}`));


### PR DESCRIPTION
Hello! Cool project, good job on it!

This pull request fixes a potential bug where a filename like `file.jolly.jolly` gets replaced by `file.js.jolly` because the code uses `.replace('.jolly', '.js')`, instead of using the `path.basename()` function.